### PR TITLE
Initialize currents and self-consistent charge instead of Ex

### DIFF
--- a/TPS_F.H
+++ b/TPS_F.H
@@ -12,7 +12,8 @@ extern "C" {
 
   void tps_fft_init(
     const int* global_lo, const int* global_hi,
-    const int* local_lo, const int* local_hi);
+    const int* local_lo, const int* local_hi,
+    Real* dx, Real* dy, Real* dz, Real* dt );
 
   void tps_push_eb(
     amrex_real* ex, const int* exlo, const int* exhi,

--- a/Viz.py
+++ b/Viz.py
@@ -14,16 +14,17 @@ for i in range(20):
                            dims=ds.domain_dimensions)
     Ex = ad0['Ex'].to_ndarray()
     Nx, Ny, Nz = Ex.shape
-
+    vmax = 0.1
+    
     plt.figure(figsize=(10,5))
     plt.subplot(131)
-    plt.imshow( Ex[int(Nx/2),:,:], vmin=-0.01, vmax=0.01 )
+    plt.imshow( Ex[int(Nx/2),:,:], vmin=-vmax, vmax=vmax )
     plt.title('y-z plane')
     plt.subplot(132)
-    plt.imshow( Ex[:,int(Ny/2),:], vmin=-0.01, vmax=0.01 )
+    plt.imshow( Ex[:,int(Ny/2),:], vmin=-vmax, vmax=vmax )
     plt.title('x-z plane')
     plt.subplot(133)
-    plt.imshow( Ex[:,:,int(Nz/2)], vmin=-0.01, vmax=0.01 )
+    plt.imshow( Ex[:,:,int(Nz/2)], vmin=-vmax, vmax=vmax )
     plt.title('x-y plane')
     
     plt.savefig('png/img%05d.png' %i)

--- a/Viz.py
+++ b/Viz.py
@@ -7,24 +7,33 @@ if os.path.exists('png'):
     shutil.rmtree('png')
 os.mkdir('png')
 
+
+def plot_field(field, line, ad0, vmax):
+    F = ad0[field].to_ndarray()
+    Nx, Ny, Nz = F.shape
+    if vmax is not None:
+        vmin = -vmax
+    else:
+        vmin = None
+    plt.subplot2grid( (4,3), (line,0))
+    plt.imshow( F[int(Nx/2),:,:], vmin=vmin, vmax=vmax, origin='lower' )
+    plt.title(field + ': y-z plane')
+    plt.subplot2grid( (4,3), (line,1))
+    plt.imshow( F[:,int(Ny/2),:], vmin=vmin, vmax=vmax, origin='lower' )
+    plt.title(field + ': x-z plane')
+    plt.subplot2grid( (4,3), (line,2))
+    plt.imshow( F[:,:,int(Nz/2)], vmin=vmin, vmax=vmax, origin='lower' )
+    plt.title(field + ': x-y plane')
+
 for i in range(20):
     ds = yt.load('./data/plt%05d' %i)
     ad0 = ds.covering_grid(level=0,
                            left_edge=ds.domain_left_edge,
                            dims=ds.domain_dimensions)
-    Ex = ad0['Ex'].to_ndarray()
-    Nx, Ny, Nz = Ex.shape
-    vmax = 0.1
     
-    plt.figure(figsize=(10,5))
-    plt.subplot(131)
-    plt.imshow( Ex[int(Nx/2),:,:], vmin=-vmax, vmax=vmax )
-    plt.title('y-z plane')
-    plt.subplot(132)
-    plt.imshow( Ex[:,int(Ny/2),:], vmin=-vmax, vmax=vmax )
-    plt.title('x-z plane')
-    plt.subplot(133)
-    plt.imshow( Ex[:,:,int(Nz/2)], vmin=-vmax, vmax=vmax )
-    plt.title('x-y plane')
-    
+    plt.figure(figsize=(10,12))
+    plot_field('Ex', 0, ad0, vmax=0.1)
+    plot_field('jx', 1, ad0, vmax=0.1)
+    plot_field('rho1', 2, ad0, vmax=None)
+    plot_field('rho2', 3, ad0, vmax=None)
     plt.savefig('png/img%05d.png' %i)

--- a/Viz.py
+++ b/Viz.py
@@ -8,32 +8,37 @@ if os.path.exists('png'):
 os.mkdir('png')
 
 
-def plot_field(field, line, ad0, vmax):
+def plot_field(field, line, nlines, ad0, vmax):
     F = ad0[field].to_ndarray()
     Nx, Ny, Nz = F.shape
     if vmax is not None:
         vmin = -vmax
     else:
         vmin = None
-    plt.subplot2grid( (4,3), (line,0))
+    plt.subplot2grid( (nlines,3), (line,0))
     plt.imshow( F[int(Nx/2),:,:], vmin=vmin, vmax=vmax, origin='lower' )
+#    plt.colorbar()
     plt.title(field + ': y-z plane')
-    plt.subplot2grid( (4,3), (line,1))
+    plt.subplot2grid( (nlines,3), (line,1))
     plt.imshow( F[:,int(Ny/2),:], vmin=vmin, vmax=vmax, origin='lower' )
+#    plt.colorbar()
     plt.title(field + ': x-z plane')
-    plt.subplot2grid( (4,3), (line,2))
+    plt.subplot2grid( (nlines,3), (line,2))
     plt.imshow( F[:,:,int(Nz/2)], vmin=vmin, vmax=vmax, origin='lower' )
+#    plt.colorbar()
     plt.title(field + ': x-y plane')
+
 
 for i in range(20):
     ds = yt.load('./data/plt%05d' %i)
     ad0 = ds.covering_grid(level=0,
                            left_edge=ds.domain_left_edge,
                            dims=ds.domain_dimensions)
-    
-    plt.figure(figsize=(10,12))
-    plot_field('Ex', 0, ad0, vmax=0.1)
-    plot_field('jx', 1, ad0, vmax=0.1)
-    plot_field('rho1', 2, ad0, vmax=None)
-    plot_field('rho2', 3, ad0, vmax=None)
+    nlines = 4
+    plt.figure(figsize=(10,nlines*4))
+    plot_field('Ex', 0, nlines, ad0, vmax=0.1)
+    plot_field('Ey', 1, nlines, ad0, vmax=0.4)
+    plot_field('Ez', 2, nlines, ad0, vmax=0.4)
+    plot_field('rho1', 3, nlines, ad0, vmax=None)
+#    plot_field('rho2', 4, nlines, ad0, vmax=None)
     plt.savefig('png/img%05d.png' %i)

--- a/Viz.py
+++ b/Viz.py
@@ -36,9 +36,9 @@ for i in range(20):
                            dims=ds.domain_dimensions)
     nlines = 4
     plt.figure(figsize=(10,nlines*4))
-    plot_field('Ex', 0, nlines, ad0, vmax=0.1)
-    plot_field('Ey', 1, nlines, ad0, vmax=0.4)
-    plot_field('Ez', 2, nlines, ad0, vmax=0.4)
+    plot_field('Ex', 0, nlines, ad0, vmax=0.03)
+    plot_field('Ey', 1, nlines, ad0, vmax=0.03)
+    plot_field('Ez', 2, nlines, ad0, vmax=0.03)
     plot_field('rho1', 3, nlines, ad0, vmax=None)
 #    plot_field('rho2', 4, nlines, ad0, vmax=None)
     plt.savefig('png/img%05d.png' %i)

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@ using namespace amrex;
 
 namespace
 {
-    Vector<int> n_cell({32, 32, 32});
+    Vector<int> n_cell({128, 128, 128});
     int max_grid_size = 32;
     int max_step = 20;
     int plot_int = 1;

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@ using namespace amrex;
 
 namespace
 {
-    Vector<int> n_cell({128, 128, 128});
+    Vector<int> n_cell({32, 32, 32});
     int max_grid_size = 32;
     int max_step = 20;
     int plot_int = 1;

--- a/tps.F90
+++ b/tps.F90
@@ -98,7 +98,8 @@ contains
   !
   ! __________________________________________________________________________
 
-  SUBROUTINE tps_fft_init( global_lo, global_hi, local_lo, local_hi) &
+  SUBROUTINE tps_fft_init( global_lo, global_hi, local_lo, local_hi, &
+       dx_wrpx, dy_wrpx, dz_wrpx, dt_wrpx) &
        BIND(C,name='tps_fft_init')
 
     USE shared_data, only: rank, comm, c_dim, p3dfft_flag, &
@@ -128,8 +129,9 @@ contains
 
     integer, intent(in) :: global_lo(BL_SPACEDIM), global_hi(BL_SPACEDIM)
     integer, intent(in) :: local_lo(BL_SPACEDIM), local_hi(BL_SPACEDIM)
+    REAL(num), intent(in) :: dx_wrpx, dy_wrpx, dz_wrpx, dt_wrpx
     integer :: nx_padded
-
+    
 !    CALL DFFTW_INIT_THREADS(iret)
     !    fftw_threads_ok = .TRUE.
     PRINT *, rank, local_lo(1), local_lo(2), local_lo(3)
@@ -165,10 +167,10 @@ contains
     norderx = 16_idp
     nordery = 16_idp
     norderz = 16_idp
-    dx = 1.
-    dy = 1.
-    dz = 1.
-    dt = 2 * dz/clight
+    dx = dx_wrpx;
+    dy = dy_wrpx;
+    dz = dz_wrpx;
+    dt = dt_wrpx;    
     ! Define parameters of FFT plans
     c_dim = INT(AMREX_SPACEDIM,idp)   ! Dimensionality of the simulation (2d/3d)
     fftw_with_mpi = .TRUE. ! Activate MPI FFTW

--- a/tps.F90
+++ b/tps.F90
@@ -164,9 +164,9 @@ contains
     
     ! For the calculation of the modified [k] vectors
     l_staggered = .TRUE.
-    norderx = 2_idp
-    nordery = 2_idp
-    norderz = 2_idp
+    norderx = 16_idp
+    nordery = 16_idp
+    norderz = 16_idp
     dx = dx_wrpx;
     dy = dy_wrpx;
     dz = dz_wrpx;

--- a/tps.F90
+++ b/tps.F90
@@ -164,9 +164,9 @@ contains
     
     ! For the calculation of the modified [k] vectors
     l_staggered = .TRUE.
-    norderx = 16_idp
-    nordery = 16_idp
-    norderz = 16_idp
+    norderx = 2_idp
+    nordery = 2_idp
+    norderz = 2_idp
     dx = dx_wrpx;
     dy = dy_wrpx;
     dz = dz_wrpx;


### PR DESCRIPTION
In order to avoid issues with div(E) and rho, this pull request initializes Jx instead of Ex. 
Jx is only non-zero during the first iteration.
The corresponding rho1 and rho2 are calculated using the continuity equation.